### PR TITLE
implementation for EIO and UIO based on ZIO

### DIFF
--- a/core/src/main/java/com/github/tonivade/purefun/Nothing.java
+++ b/core/src/main/java/com/github/tonivade/purefun/Nothing.java
@@ -5,7 +5,7 @@
 package com.github.tonivade.purefun;
 
 /**
- * It represents a type that cannot be instantiated. Similar to {@link Void} * type
+ * It represents a type that cannot be instantiated. Similar to {@link Void} type
  * in JVM but is not a substitution for {@code void}
  */
 public final class Nothing {

--- a/instances/src/main/java/com/github/tonivade/purefun/instances/EIOInstances.java
+++ b/instances/src/main/java/com/github/tonivade/purefun/instances/EIOInstances.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018-2019, Antonio Gabriel Muñoz Conejo <antoniogmc at gmail dot com>
+ * Distributed under the terms of the MIT License
+ */
+package com.github.tonivade.purefun.instances;
+
+import com.github.tonivade.purefun.Consumer1;
+import com.github.tonivade.purefun.Function1;
+import com.github.tonivade.purefun.Higher1;
+import com.github.tonivade.purefun.Higher2;
+import com.github.tonivade.purefun.Instance;
+import com.github.tonivade.purefun.Producer;
+import com.github.tonivade.purefun.typeclasses.Applicative;
+import com.github.tonivade.purefun.typeclasses.Bracket;
+import com.github.tonivade.purefun.typeclasses.Defer;
+import com.github.tonivade.purefun.typeclasses.Functor;
+import com.github.tonivade.purefun.typeclasses.Monad;
+import com.github.tonivade.purefun.typeclasses.MonadDefer;
+import com.github.tonivade.purefun.typeclasses.MonadError;
+import com.github.tonivade.purefun.typeclasses.MonadThrow;
+import com.github.tonivade.purefun.typeclasses.Reference;
+import com.github.tonivade.purefun.zio.EIO;
+
+public interface EIOInstances {
+
+  static <E> Functor<Higher1<EIO.µ, E>> functor() {
+    return new EIOFunctor<E>() {};
+  }
+
+  static <E> Applicative<Higher1<EIO.µ, E>> applicative() {
+    return new EIOApplicative<E>() {};
+  }
+
+  static <E> Monad<Higher1<EIO.µ, E>> monad() {
+    return new EIOMonad<E>() {};
+  }
+
+  static <E> MonadError<Higher1<EIO.µ, E>, E> monadError() {
+    return new EIOMonadError<E>() {};
+  }
+
+  static MonadThrow<Higher1<EIO.µ, Throwable>> monadThrow() {
+    return new EIOMonadThrow() { };
+  }
+
+  static MonadDefer<Higher1<EIO.µ, Throwable>> monadDefer() {
+    return new EIOMonadDefer() { };
+  }
+
+  static <A> Reference<Higher1<EIO.µ, Throwable>, A> ref(A value) {
+    return Reference.of(monadDefer(), value);
+  }
+}
+
+@Instance
+interface EIOFunctor<E> extends Functor<Higher1<EIO.µ, E>> {
+
+  @Override
+  default <A, B> Higher2<EIO.µ, E, B>
+          map(Higher1<Higher1<EIO.µ, E>, A> value, Function1<A, B> map) {
+    return EIO.narrowK(value).map(map).kind2();
+  }
+}
+
+@Instance
+interface EIOPure<E> extends Applicative<Higher1<EIO.µ, E>> {
+
+  @Override
+  default <A> Higher2<EIO.µ, E, A> pure(A value) {
+    return EIO.<E, A>pure(value).kind2();
+  }
+}
+
+@Instance
+interface EIOApplicative<E> extends EIOPure<E> {
+
+  @Override
+  default <A, B> Higher2<EIO.µ, E, B>
+          ap(Higher1<Higher1<EIO.µ, E>, A> value,
+             Higher1<Higher1<EIO.µ, E>, Function1<A, B>> apply) {
+    return EIO.narrowK(apply).flatMap(map -> EIO.narrowK(value).map(map)).kind2();
+  }
+}
+
+@Instance
+interface EIOMonad<E> extends EIOPure<E>, Monad<Higher1<EIO.µ, E>> {
+
+  @Override
+  default <A, B> Higher2<EIO.µ, E, B>
+          flatMap(Higher1<Higher1<EIO.µ, E>, A> value,
+                  Function1<A, ? extends Higher1<Higher1<EIO.µ, E>, B>> map) {
+    return EIO.narrowK(value).flatMap(map.andThen(EIO::narrowK)).kind2();
+  }
+}
+
+@Instance
+interface EIOMonadError<E> extends EIOMonad<E>, MonadError<Higher1<EIO.µ, E>, E> {
+
+  @Override
+  default <A> Higher2<EIO.µ, E, A> raiseError(E error) {
+    return EIO.<E, A>raiseError(error).kind2();
+  }
+
+  @Override
+  default <A> Higher2<EIO.µ, E, A>
+          handleErrorWith(Higher1<Higher1<EIO.µ,  E>, A> value,
+                          Function1<E, ? extends Higher1<Higher1<EIO.µ, E>, A>> handler) {
+    // XXX: java8 fails to infer types, I have to do this in steps
+    Function1<E, EIO<E, A>> mapError = handler.andThen(EIO::narrowK);
+    Function1<A, EIO<E, A>> map = EIO::pure;
+    EIO<E, A> eio = EIO.narrowK(value);
+    return eio.foldM(mapError, map).kind2();
+  }
+}
+
+@Instance
+interface EIOMonadThrow
+    extends EIOMonadError<Throwable>,
+            MonadThrow<Higher1<EIO.µ, Throwable>> { }
+
+@Instance
+interface EIODefer extends Defer<Higher1<EIO.µ, Throwable>> {
+
+  @Override
+  default <A> Higher2<EIO.µ, Throwable, A>
+          defer(Producer<Higher1<Higher1<EIO.µ, Throwable>, A>> defer) {
+    return EIO.defer(() -> defer.map(EIO::narrowK).get()).kind2();
+  }
+}
+
+@Instance
+interface EIOBracket extends Bracket<Higher1<EIO.µ, Throwable>> {
+
+  @Override
+  default <A, B> Higher2<EIO.µ, Throwable, B>
+          bracket(Higher1<Higher1<EIO.µ, Throwable>, A> acquire,
+                  Function1<A, ? extends Higher1<Higher1<EIO.µ, Throwable>, B>> use,
+                  Consumer1<A> release) {
+    return EIO.bracket(acquire.fix1(EIO::narrowK), use.andThen(EIO::narrowK), release).kind2();
+  }
+}
+
+@Instance
+interface EIOMonadDefer
+    extends MonadDefer<Higher1<EIO.µ, Throwable>>,
+            EIOMonadThrow,
+            EIODefer,
+            EIOBracket { }

--- a/instances/src/main/java/com/github/tonivade/purefun/instances/UIOInstances.java
+++ b/instances/src/main/java/com/github/tonivade/purefun/instances/UIOInstances.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018-2019, Antonio Gabriel Muñoz Conejo <antoniogmc at gmail dot com>
+ * Distributed under the terms of the MIT License
+ */
+package com.github.tonivade.purefun.instances;
+
+import com.github.tonivade.purefun.Consumer1;
+import com.github.tonivade.purefun.Function1;
+import com.github.tonivade.purefun.Higher1;
+import com.github.tonivade.purefun.Higher2;
+import com.github.tonivade.purefun.Instance;
+import com.github.tonivade.purefun.Producer;
+import com.github.tonivade.purefun.typeclasses.Applicative;
+import com.github.tonivade.purefun.typeclasses.Bracket;
+import com.github.tonivade.purefun.typeclasses.Defer;
+import com.github.tonivade.purefun.typeclasses.Functor;
+import com.github.tonivade.purefun.typeclasses.Monad;
+import com.github.tonivade.purefun.typeclasses.MonadDefer;
+import com.github.tonivade.purefun.typeclasses.MonadError;
+import com.github.tonivade.purefun.typeclasses.MonadThrow;
+import com.github.tonivade.purefun.typeclasses.Reference;
+import com.github.tonivade.purefun.zio.EIO;
+import com.github.tonivade.purefun.zio.UIO;
+
+public interface UIOInstances {
+
+  static <E> Functor<Higher1<EIO.µ, E>> functor() {
+    return new EIOFunctor<E>() {};
+  }
+
+  static <E> Applicative<Higher1<EIO.µ, E>> applicative() {
+    return new EIOApplicative<E>() {};
+  }
+
+  static <E> Monad<Higher1<EIO.µ, E>> monad() {
+    return new EIOMonad<E>() {};
+  }
+
+  static <E> MonadError<Higher1<EIO.µ, E>, E> monadError() {
+    return new EIOMonadError<E>() {};
+  }
+
+  static MonadThrow<Higher1<EIO.µ, Throwable>> monadThrow() {
+    return new EIOMonadThrow() { };
+  }
+
+  static MonadDefer<Higher1<EIO.µ, Throwable>> monadDefer() {
+    return new EIOMonadDefer() { };
+  }
+
+  static <A> Reference<Higher1<EIO.µ, Throwable>, A> ref(A value) {
+    return Reference.of(monadDefer(), value);
+  }
+}
+
+@Instance
+interface UIOFunctor extends Functor<UIO.µ> {
+
+  @Override
+  default <A, B> Higher1<UIO.µ, B> map(Higher1<UIO.µ, A> value, Function1<A, B> map) {
+    return UIO.narrowK(value).map(map).kind1();
+  }
+}
+
+@Instance
+interface UIOPure extends Applicative<UIO.µ> {
+
+  @Override
+  default <A> Higher1<UIO.µ, A> pure(A value) {
+    return UIO.<A>pure(value).kind1();
+  }
+}
+
+@Instance
+interface UIOApplicative extends UIOPure {
+
+  @Override
+  default <A, B> Higher1<UIO.µ, B> ap(Higher1<UIO.µ, A> value, Higher1<UIO.µ, Function1<A, B>> apply) {
+    return UIO.narrowK(apply).flatMap(map -> UIO.narrowK(value).map(map)).kind1();
+  }
+}
+
+@Instance
+interface UIOMonad extends UIOPure, Monad<UIO.µ> {
+
+  @Override
+  default <A, B> Higher1<UIO.µ, B> flatMap(Higher1<UIO.µ, A> value, Function1<A, ? extends Higher1<UIO.µ, B>> map) {
+    return UIO.narrowK(value).flatMap(map.andThen(UIO::narrowK)).kind1();
+  }
+}
+
+@Instance
+interface UIOMonadError extends UIOMonad, MonadError<UIO.µ, Throwable> {
+
+  @Override
+  default <A> Higher1<UIO.µ, A> raiseError(Throwable error) {
+    return UIO.<A>raiseError(error).kind1();
+  }
+
+  @Override
+  default <A> Higher1<UIO.µ, A>
+          handleErrorWith(Higher1<UIO.µ, A> value,
+                          Function1<Throwable, ? extends Higher1<UIO.µ, A>> handler) {
+    // XXX: java8 fails to infer types, I have to do this in steps
+    Function1<Throwable, UIO<A>> mapError = handler.andThen(UIO::narrowK);
+    Function1<A, UIO<A>> map = UIO::pure;
+    UIO<A> uio = UIO.narrowK(value);
+    // TODO: foldM
+    // return uio.foldM(mapError, map).kind2();
+    return null;
+  }
+}
+
+@Instance
+interface UIOMonadThrow
+    extends UIOMonadError,
+            MonadThrow<UIO.µ> { }
+
+@Instance
+interface UIODefer extends Defer<UIO.µ> {
+
+  @Override
+  default <A> Higher1<UIO.µ, A>
+          defer(Producer<Higher1<UIO.µ, A>> defer) {
+    return UIO.defer(() -> defer.map(UIO::narrowK).get()).kind1();
+  }
+}
+
+@Instance
+interface UIOBracket extends Bracket<UIO.µ> {
+
+  @Override
+  default <A, B> Higher1<UIO.µ, B>
+          bracket(Higher1<UIO.µ, A> acquire,
+                  Function1<A, ? extends Higher1<UIO.µ, B>> use,
+                  Consumer1<A> release) {
+    // TODO: bracket
+    // return UIO.bracket(acquire.fix1(UIO::narrowK), use.andThen(UIO::narrowK), release).kind1();
+    return null;
+  }
+}
+
+@Instance
+interface UIOMonadDefer
+    extends MonadDefer<UIO.µ>,
+            UIOMonadThrow,
+            UIODefer,
+            UIOBracket { }

--- a/instances/src/main/java/com/github/tonivade/purefun/instances/UIOInstances.java
+++ b/instances/src/main/java/com/github/tonivade/purefun/instances/UIOInstances.java
@@ -102,7 +102,7 @@ interface UIOMonadError extends UIOMonad, MonadError<UIO.µ, Throwable> {
     Function1<Throwable, UIO<A>> mapError = handler.andThen(UIO::narrowK);
     Function1<A, UIO<A>> map = UIO::pure;
     UIO<A> uio = UIO.narrowK(value);
-    return uio.foldM(mapError, map).kind1();
+    return uio.redeemWith(mapError, map).kind1();
   }
 }
 
@@ -129,9 +129,7 @@ interface UIOBracket extends Bracket<UIO.µ> {
           bracket(Higher1<UIO.µ, A> acquire,
                   Function1<A, ? extends Higher1<UIO.µ, B>> use,
                   Consumer1<A> release) {
-    // TODO: bracket
-    // return UIO.bracket(acquire.fix1(UIO::narrowK), use.andThen(UIO::narrowK), release).kind1();
-    return null;
+    return UIO.bracket(acquire.fix1(UIO::narrowK), use.andThen(UIO::narrowK), release).kind1();
   }
 }
 

--- a/instances/src/main/java/com/github/tonivade/purefun/instances/UIOInstances.java
+++ b/instances/src/main/java/com/github/tonivade/purefun/instances/UIOInstances.java
@@ -65,7 +65,7 @@ interface UIOPure extends Applicative<UIO.µ> {
 
   @Override
   default <A> Higher1<UIO.µ, A> pure(A value) {
-    return UIO.<A>pure(value).kind1();
+    return UIO.pure(value).kind1();
   }
 }
 

--- a/zio/src/main/java/com/github/tonivade/purefun/zio/EIO.java
+++ b/zio/src/main/java/com/github/tonivade/purefun/zio/EIO.java
@@ -37,7 +37,7 @@ public final class EIO<E, T> {
     return (ZIO<R, E, T>) value;
   }
 
-  public Either<E, T> run() {
+  public Either<E, T> safeRunSync() {
     return value.provide(nothing());
   }
 

--- a/zio/src/main/java/com/github/tonivade/purefun/zio/EIO.java
+++ b/zio/src/main/java/com/github/tonivade/purefun/zio/EIO.java
@@ -25,11 +25,11 @@ import static com.github.tonivade.purefun.Nothing.nothing;
 import static java.util.Objects.requireNonNull;
 
 @HigherKind
-public class EIO<E, T> {
+public final class EIO<E, T> {
 
   private final ZIO<Nothing, E, T> value;
 
-  private EIO(ZIO<Nothing, E, T> value) {
+  EIO(ZIO<Nothing, E, T> value) {
     this.value = requireNonNull(value);
   }
 

--- a/zio/src/main/java/com/github/tonivade/purefun/zio/EIO.java
+++ b/zio/src/main/java/com/github/tonivade/purefun/zio/EIO.java
@@ -97,12 +97,12 @@ public final class EIO<E, T> {
     return new EIO<>(value.foldM(error -> mapError.apply(error).value, value -> map.apply(value).value));
   }
 
-  public <B> EIO<Nothing, B> fold(Function1<E, B> mapError, Function1<T, B> map) {
-    return new EIO<>(value.fold(mapError, map));
+  public <B> UIO<B> fold(Function1<E, B> mapError, Function1<T, B> map) {
+    return new UIO<>(value.fold(mapError, map));
   }
 
-  public EIO<Nothing, T> recover(Function1<E, T> mapError) {
-    return new EIO<>(value.recover(mapError));
+  public UIO<T> recover(Function1<E, T> mapError) {
+    return new UIO<>(value.recover(mapError));
   }
 
   public EIO<E, T> orElse(Producer<EIO<E, T>> other) {

--- a/zio/src/main/java/com/github/tonivade/purefun/zio/EIO.java
+++ b/zio/src/main/java/com/github/tonivade/purefun/zio/EIO.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2018-2019, Antonio Gabriel Muñoz Conejo <antoniogmc at gmail dot com>
+ * Distributed under the terms of the MIT License
+ */
+package com.github.tonivade.purefun.zio;
+
+import com.github.tonivade.purefun.CheckedRunnable;
+import com.github.tonivade.purefun.Consumer1;
+import com.github.tonivade.purefun.Function1;
+import com.github.tonivade.purefun.Function2;
+import com.github.tonivade.purefun.Higher1;
+import com.github.tonivade.purefun.HigherKind;
+import com.github.tonivade.purefun.Kind;
+import com.github.tonivade.purefun.Nothing;
+import com.github.tonivade.purefun.Producer;
+import com.github.tonivade.purefun.Unit;
+import com.github.tonivade.purefun.concurrent.Future;
+import com.github.tonivade.purefun.type.Either;
+import com.github.tonivade.purefun.type.Try;
+import com.github.tonivade.purefun.typeclasses.MonadDefer;
+
+import java.util.concurrent.Executor;
+
+import static com.github.tonivade.purefun.Nothing.nothing;
+import static java.util.Objects.requireNonNull;
+
+@HigherKind
+public class EIO<E, T> {
+
+  private final ZIO<Nothing, E, T> value;
+
+  private EIO(ZIO<Nothing, E, T> value) {
+    this.value = requireNonNull(value);
+  }
+
+  public <R> ZIO<R, E, T> toZIO() {
+    return (ZIO<R, E, T>) value;
+  }
+
+  public Either<E, T> run() {
+    return value.provide(nothing());
+  }
+
+  public Future<Either<E, T>> toFuture(Executor executor) {
+    return value.toFuture(executor, nothing());
+  }
+
+  public Future<Either<E, T>> toFuture() {
+    return value.toFuture(nothing());
+  }
+
+  public void async(Executor executor, Consumer1<Try<Either<E, T>>> callback) {
+    value.provideAsync(executor, nothing(), callback);
+  }
+
+  public void async(Consumer1<Try<Either<E, T>>> callback) {
+    value.provideAsync(nothing(), callback);
+  }
+
+  public <F extends Kind> Higher1<F, Either<E, T>> foldMap(MonadDefer<F> monad) {
+    return value.foldMap(nothing(), monad);
+  }
+
+  public <B> EIO<E, B> map(Function1<T, B> map) {
+    return new EIO<>(value.map(map));
+  }
+
+  public <B> EIO<E, B> flatMap(Function1<T, EIO<E, B>> map) {
+    return new EIO<>(value.flatMap(value -> map.apply(value).value));
+  }
+
+  public <B> EIO<E, B> flatten() {
+    return new EIO<>(value.flatten());
+  }
+
+  public EIO<T, E> swap() {
+    return new EIO<>(value.swap());
+  }
+
+  public <B> EIO<B, T> mapError(Function1<E, B> map) {
+    return new EIO<>(value.mapError(map));
+  }
+
+  public <F> EIO<F, T> flatMapError(Function1<E, EIO<F, T>> map) {
+    return new EIO<>(value.flatMapError(error -> map.apply(error).value));
+  }
+
+  public <B, F> EIO<F, B> bimap(Function1<E, F> mapError, Function1<T, B> map) {
+    return new EIO<>(value.bimap(mapError, map));
+  }
+
+  public <B> EIO<E, B> andThen(EIO<E, B> next) {
+    return new EIO<>(value.andThen(next.value));
+  }
+
+  public <B, F> EIO<F, B> foldM(Function1<E, EIO<F, B>> mapError, Function1<T, EIO<F, B>> map) {
+    return new EIO<>(value.foldM(error -> mapError.apply(error).value, value -> map.apply(value).value));
+  }
+
+  public <B> EIO<Nothing, B> fold(Function1<E, B> mapError, Function1<T, B> map) {
+    return new EIO<>(value.fold(mapError, map));
+  }
+
+  public EIO<Nothing, T> recover(Function1<E, T> mapError) {
+    return new EIO<>(value.recover(mapError));
+  }
+
+  public EIO<E, T> orElse(Producer<EIO<E, T>> other) {
+    return new EIO<>(value.orElse(() -> other.get().value));
+  }
+
+  public static <E1, A, B, C> EIO<E1, C> map2(EIO<E1, A> za, EIO<E1, B> zb, Function2<A, B, C> mapper) {
+    return new EIO<>(ZIO.map2(za.value, zb.value, mapper));
+  }
+
+  public static <E1, A> EIO<E1, A> absorb(EIO<E1, Either<E1, A>> value) {
+    return new EIO<>(ZIO.absorb(value.value));
+  }
+
+  public static <A, B> Function1<A, EIO<Throwable, B>> lift(Function1<A, B> function) {
+    return ZIO.<Nothing, A, B>lift(function).andThen(EIO::new);
+  }
+
+  public static <E1, A> EIO<E1, A> fromEither(Producer<Either<E1, A>> task) {
+    return new EIO<>(ZIO.fromEither(task));
+  }
+
+  public static <R, A> EIO<Throwable, A> from(Producer<A> task) {
+    return new EIO<>(ZIO.from(task));
+  }
+
+  public static EIO<Throwable, Unit> exec(CheckedRunnable task) {
+    return new EIO<>(ZIO.exec(task));
+  }
+
+  public static <E, A> EIO<E, A> pure(A value) {
+    return new EIO<>(ZIO.pure(value));
+  }
+
+  public static <E, A> EIO<E, A> defer(Producer<EIO<E, A>> lazy) {
+    return new EIO<>(ZIO.defer(() -> lazy.get().value));
+  }
+
+  public static <E, A> EIO<E, A> task(Producer<A> task) {
+    return new EIO<>(ZIO.task(task));
+  }
+
+  public static <E, A> EIO<E, A> raiseError(E error) {
+    return new EIO<>(ZIO.raiseError(error));
+  }
+
+  public static <A extends AutoCloseable, B> EIO<Throwable, B> bracket(EIO<Throwable, A> acquire, Function1<A, EIO<Throwable, B>> use) {
+    return new EIO<>(ZIO.bracket(acquire.value, resource -> use.apply(resource).value));
+  }
+
+  public static <A, B> EIO<Throwable, B> bracket(EIO<Throwable, A> acquire, Function1<A, EIO<Throwable, B>> use, Consumer1<A> release) {
+    return new EIO<>(ZIO.bracket(acquire.value, resource -> use.apply(resource).value, release));
+  }
+
+  public static <E> EIO<E, Unit> unit() {
+    return new EIO<>(ZIO.unit());
+  }
+}

--- a/zio/src/main/java/com/github/tonivade/purefun/zio/UIO.java
+++ b/zio/src/main/java/com/github/tonivade/purefun/zio/UIO.java
@@ -34,7 +34,7 @@ public final class UIO<T> {
     this.value = requireNonNull(value);
   }
 
-  public T run() {
+  public T unsafeRunSync() {
     return value.provide(nothing()).get();
   }
 

--- a/zio/src/main/java/com/github/tonivade/purefun/zio/UIO.java
+++ b/zio/src/main/java/com/github/tonivade/purefun/zio/UIO.java
@@ -81,6 +81,10 @@ public final class UIO<T> {
     return new UIO<>(value.andThen(next.value));
   }
 
+  public <B> UIO<B> fold(Function1<Throwable, B> mapError, Function1<T, B> map) {
+    return foldM(mapError.andThen(UIO::pure), map.andThen(UIO::pure));
+  }
+
   public <B> UIO<B> foldM(Function1<Throwable, UIO<B>> mapError, Function1<T, UIO<B>> map) {
     return new UIO<>(ZIO.redeem(value, error -> mapError.apply(error).value, x -> map.apply(x).value));
   }

--- a/zio/src/main/java/com/github/tonivade/purefun/zio/UIO.java
+++ b/zio/src/main/java/com/github/tonivade/purefun/zio/UIO.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018-2019, Antonio Gabriel Muñoz Conejo <antoniogmc at gmail dot com>
+ * Distributed under the terms of the MIT License
+ */
+package com.github.tonivade.purefun.zio;
+
+import com.github.tonivade.purefun.CheckedRunnable;
+import com.github.tonivade.purefun.Consumer1;
+import com.github.tonivade.purefun.Function1;
+import com.github.tonivade.purefun.Function2;
+import com.github.tonivade.purefun.Higher1;
+import com.github.tonivade.purefun.HigherKind;
+import com.github.tonivade.purefun.Kind;
+import com.github.tonivade.purefun.Nothing;
+import com.github.tonivade.purefun.Producer;
+import com.github.tonivade.purefun.Unit;
+import com.github.tonivade.purefun.concurrent.Future;
+import com.github.tonivade.purefun.type.Either;
+import com.github.tonivade.purefun.type.Try;
+import com.github.tonivade.purefun.typeclasses.MonadDefer;
+
+import java.util.concurrent.Executor;
+
+import static com.github.tonivade.purefun.Nothing.nothing;
+import static java.util.Objects.requireNonNull;
+
+@HigherKind
+public class UIO<T> {
+
+  private final ZIO<Nothing, Nothing, T> value;
+
+  private UIO(ZIO<Nothing, Nothing, T> value) {
+    this.value = requireNonNull(value);
+  }
+
+  public T run() {
+    return value.provide(nothing()).get();
+  }
+
+  public Future<T> toFuture(Executor executor) {
+    return value.toFuture(executor, nothing()).map(Either::get);
+  }
+
+  public Future<T> toFuture() {
+    return value.toFuture(nothing()).map(Either::get);
+  }
+
+  public void async(Executor executor, Consumer1<Try<T>> callback) {
+    value.provideAsync(executor, nothing(), result -> callback.accept(result.map(Either::get)));
+  }
+
+  public void async(Consumer1<Try<T>> callback) {
+    value.provideAsync(nothing(), result -> callback.accept(result.map(Either::get)));
+  }
+
+  public <F extends Kind> Higher1<F, T> foldMap(MonadDefer<F> monad) {
+    return monad.map(value.foldMap(nothing(), monad), Either::get);
+  }
+
+  public <B> UIO<B> map(Function1<T, B> map) {
+    return new UIO<>(value.map(map));
+  }
+
+  public <B> UIO<B> flatMap(Function1<T, UIO<B>> map) {
+    return new UIO<>(value.flatMap(x -> map.apply(x).value));
+  }
+
+  public <B> UIO<B> flatten() {
+    return new UIO<>(value.flatten());
+  }
+
+  public <B> UIO<B> andThen(UIO<B> next) {
+    return new UIO<>(value.andThen(next.value));
+  }
+
+  public static <A, B, C> UIO<C> map2(UIO<A> za, UIO<B> zb, Function2<A, B, C> mapper) {
+    return new UIO<>(ZIO.map2(za.value, zb.value, mapper));
+  }
+
+  public static <A> UIO<A> from(Producer<A> task) {
+    return new UIO<>(fold(ZIO.from(task)));
+  }
+
+  public static UIO<Unit> exec(CheckedRunnable task) {
+    return new UIO<>(fold(ZIO.exec(task)));
+  }
+
+  public static <A> UIO<A> pure(A value) {
+    return new UIO<>(ZIO.pure(value));
+  }
+
+  public static <A> UIO<A> raiseError(Throwable throwable) {
+    return new UIO<>(ZIO.task(() -> { throw throwable; }));
+  }
+
+  public static <A> UIO<A> defer(Producer<UIO<A>> lazy) {
+    return new UIO<>(ZIO.defer(() -> lazy.get().value));
+  }
+
+  public static <A> UIO<A> task(Producer<A> task) {
+    return new UIO<>(ZIO.task(task));
+  }
+
+  public static UIO<Unit> unit() {
+    return new UIO<>(ZIO.unit());
+  }
+
+  private static <A> ZIO<Nothing, Nothing, A> fold(ZIO<Nothing, Throwable, A> zio) {
+    return zio.foldM(error -> UIO.<A>raiseError(error).value, value -> pure(value).value);
+  }
+}

--- a/zio/src/test/java/com/github/tonivade/purefun/zio/EIOTest.java
+++ b/zio/src/test/java/com/github/tonivade/purefun/zio/EIOTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2018-2019, Antonio Gabriel Muñoz Conejo <antoniogmc at gmail dot com>
+ * Distributed under the terms of the MIT License
+ */
+package com.github.tonivade.purefun.zio;
+
+import static com.github.tonivade.purefun.Function1.identity;
+import static com.github.tonivade.purefun.zio.EIO.from;
+import static com.github.tonivade.purefun.zio.EIO.pure;
+import static com.github.tonivade.purefun.zio.EIO.raiseError;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.tonivade.purefun.Function1;
+import com.github.tonivade.purefun.Nothing;
+import com.github.tonivade.purefun.type.Either;
+import org.junit.jupiter.api.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class EIOTest {
+
+  @Test
+  public void mapRight() {
+    Either<Throwable, Integer> result = parseInt("1").map(x -> x + 1).run();
+
+    assertEquals(Either.right(2), result);
+  }
+
+  @Test
+  public void mapLeft() {
+    Either<Throwable, Integer> result = parseInt("lskjdf").map(x -> x + 1).run();
+
+    assertEquals(NumberFormatException.class, result.getLeft().getClass());
+  }
+
+  @Test
+  public void mapError() {
+    Either<String, Integer> result = parseInt("lskjdf").mapError(Throwable::getMessage).run();
+
+    assertEquals(Either.left("For input string: \"lskjdf\""), result);
+  }
+
+  @Test
+  public void flatMapRight() {
+    Either<Throwable, Integer> result = parseInt("1").flatMap(x -> pure(x + 1)).run();
+
+    assertEquals(Either.right(2), result);
+  }
+
+  @Test
+  public void flatMapLeft() {
+    Either<Throwable, Integer> result = parseInt("lskjdf").flatMap(x -> pure(x + 1)).run();
+
+    assertEquals(NumberFormatException.class, result.getLeft().getClass());
+  }
+
+  @Test
+  public void flatMapError() {
+    Either<String, Integer> result = parseInt("lskjdf").flatMapError(e -> raiseError(e.getMessage())).run();
+
+    assertEquals(Either.left("For input string: \"lskjdf\""), result);
+  }
+
+  @Test
+  public void bimapRight() {
+    Either<String, Integer> result =
+        parseInt("1").bimap(Throwable::getMessage, x -> x + 1).run();
+
+    assertEquals(Either.right(2), result);
+  }
+
+  @Test
+  public void bimapLeft() {
+    Either<String, Integer> result =
+        parseInt("lskjdf").bimap(Throwable::getMessage, x -> x + 1).run();
+
+    assertEquals(Either.left("For input string: \"lskjdf\""), result);
+  }
+
+  @Test
+  public void foldRight() {
+    Either<Nothing, Integer> result =
+        parseInt("1").fold(e -> -1, identity()).run();
+
+    assertEquals(Either.right(1), result);
+  }
+
+  @Test
+  public void foldLeft() {
+    Either<Nothing, Integer> result =
+        parseInt("kjsdfdf").fold(e -> -1, identity()).run();
+
+    assertEquals(Either.right(-1), result);
+  }
+
+  @Test
+  public void orElseRight() {
+    Either<Throwable, Integer> result =
+        parseInt("1").orElse(() -> pure(2)).run();
+
+    assertEquals(Either.right(1), result);
+  }
+
+  @Test
+  public void orElseLeft() {
+    Either<Throwable, Integer> result =
+        parseInt("kjsdfe").orElse(() -> pure(2)).run();
+
+    assertEquals(Either.right(2), result);
+  }
+
+  @Test
+  public void bracket() throws SQLException {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.getString("id")).thenReturn("value");
+
+    EIO<Throwable, String> bracket = EIO.bracket(open(resultSet), getString("id"));
+
+    assertEquals(Either.right("value"), bracket.run());
+    verify(resultSet).close();
+  }
+
+  private EIO<Throwable, Integer> parseInt(String string) {
+    return from(() -> Integer.parseInt(string));
+  }
+
+  private EIO<Throwable, ResultSet> open(ResultSet resultSet) {
+    return pure(resultSet);
+  }
+
+  private Function1<ResultSet, EIO<Throwable, String>> getString(String column) {
+    return resultSet -> EIO.from(() -> resultSet.getString(column));
+  }
+}

--- a/zio/src/test/java/com/github/tonivade/purefun/zio/EIOTest.java
+++ b/zio/src/test/java/com/github/tonivade/purefun/zio/EIOTest.java
@@ -4,7 +4,6 @@
  */
 package com.github.tonivade.purefun.zio;
 
-import static com.github.tonivade.purefun.Function1.identity;
 import static com.github.tonivade.purefun.zio.EIO.from;
 import static com.github.tonivade.purefun.zio.EIO.pure;
 import static com.github.tonivade.purefun.zio.EIO.raiseError;
@@ -14,7 +13,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.tonivade.purefun.Function1;
-import com.github.tonivade.purefun.Nothing;
 import com.github.tonivade.purefun.type.Either;
 import org.junit.jupiter.api.Test;
 
@@ -83,32 +81,28 @@ public class EIOTest {
 
   @Test
   public void foldRight() {
-    Either<Nothing, Integer> result =
-        parseInt("1").fold(e -> -1, identity()).run();
+    Integer result = parseInt("1").recover(e -> -1).run();
 
-    assertEquals(Either.right(1), result);
+    assertEquals(1, result);
   }
 
   @Test
   public void foldLeft() {
-    Either<Nothing, Integer> result =
-        parseInt("kjsdfdf").fold(e -> -1, identity()).run();
+    Integer result = parseInt("kjsdfdf").recover(e -> -1).run();
 
-    assertEquals(Either.right(-1), result);
+    assertEquals(-1, result);
   }
 
   @Test
   public void orElseRight() {
-    Either<Throwable, Integer> result =
-        parseInt("1").orElse(() -> pure(2)).run();
+    Either<Throwable, Integer> result = parseInt("1").orElse(() -> pure(2)).run();
 
     assertEquals(Either.right(1), result);
   }
 
   @Test
   public void orElseLeft() {
-    Either<Throwable, Integer> result =
-        parseInt("kjsdfe").orElse(() -> pure(2)).run();
+    Either<Throwable, Integer> result = parseInt("kjsdfe").orElse(() -> pure(2)).run();
 
     assertEquals(Either.right(2), result);
   }

--- a/zio/src/test/java/com/github/tonivade/purefun/zio/EIOTest.java
+++ b/zio/src/test/java/com/github/tonivade/purefun/zio/EIOTest.java
@@ -133,6 +133,6 @@ public class EIOTest {
   }
 
   private Function1<ResultSet, EIO<Throwable, String>> getString(String column) {
-    return resultSet -> EIO.from(() -> resultSet.getString(column));
+    return resultSet -> from(() -> resultSet.getString(column));
   }
 }

--- a/zio/src/test/java/com/github/tonivade/purefun/zio/EIOTest.java
+++ b/zio/src/test/java/com/github/tonivade/purefun/zio/EIOTest.java
@@ -23,42 +23,42 @@ public class EIOTest {
 
   @Test
   public void mapRight() {
-    Either<Throwable, Integer> result = parseInt("1").map(x -> x + 1).run();
+    Either<Throwable, Integer> result = parseInt("1").map(x -> x + 1).safeRunSync();
 
     assertEquals(Either.right(2), result);
   }
 
   @Test
   public void mapLeft() {
-    Either<Throwable, Integer> result = parseInt("lskjdf").map(x -> x + 1).run();
+    Either<Throwable, Integer> result = parseInt("lskjdf").map(x -> x + 1).safeRunSync();
 
     assertEquals(NumberFormatException.class, result.getLeft().getClass());
   }
 
   @Test
   public void mapError() {
-    Either<String, Integer> result = parseInt("lskjdf").mapError(Throwable::getMessage).run();
+    Either<String, Integer> result = parseInt("lskjdf").mapError(Throwable::getMessage).safeRunSync();
 
     assertEquals(Either.left("For input string: \"lskjdf\""), result);
   }
 
   @Test
   public void flatMapRight() {
-    Either<Throwable, Integer> result = parseInt("1").flatMap(x -> pure(x + 1)).run();
+    Either<Throwable, Integer> result = parseInt("1").flatMap(x -> pure(x + 1)).safeRunSync();
 
     assertEquals(Either.right(2), result);
   }
 
   @Test
   public void flatMapLeft() {
-    Either<Throwable, Integer> result = parseInt("lskjdf").flatMap(x -> pure(x + 1)).run();
+    Either<Throwable, Integer> result = parseInt("lskjdf").flatMap(x -> pure(x + 1)).safeRunSync();
 
     assertEquals(NumberFormatException.class, result.getLeft().getClass());
   }
 
   @Test
   public void flatMapError() {
-    Either<String, Integer> result = parseInt("lskjdf").flatMapError(e -> raiseError(e.getMessage())).run();
+    Either<String, Integer> result = parseInt("lskjdf").flatMapError(e -> raiseError(e.getMessage())).safeRunSync();
 
     assertEquals(Either.left("For input string: \"lskjdf\""), result);
   }
@@ -66,7 +66,7 @@ public class EIOTest {
   @Test
   public void bimapRight() {
     Either<String, Integer> result =
-        parseInt("1").bimap(Throwable::getMessage, x -> x + 1).run();
+        parseInt("1").bimap(Throwable::getMessage, x -> x + 1).safeRunSync();
 
     assertEquals(Either.right(2), result);
   }
@@ -74,35 +74,35 @@ public class EIOTest {
   @Test
   public void bimapLeft() {
     Either<String, Integer> result =
-        parseInt("lskjdf").bimap(Throwable::getMessage, x -> x + 1).run();
+        parseInt("lskjdf").bimap(Throwable::getMessage, x -> x + 1).safeRunSync();
 
     assertEquals(Either.left("For input string: \"lskjdf\""), result);
   }
 
   @Test
   public void foldRight() {
-    Integer result = parseInt("1").recover(e -> -1).run();
+    Integer result = parseInt("1").recover(e -> -1).unsafeRunSync();
 
     assertEquals(1, result);
   }
 
   @Test
   public void foldLeft() {
-    Integer result = parseInt("kjsdfdf").recover(e -> -1).run();
+    Integer result = parseInt("kjsdfdf").recover(e -> -1).unsafeRunSync();
 
     assertEquals(-1, result);
   }
 
   @Test
   public void orElseRight() {
-    Either<Throwable, Integer> result = parseInt("1").orElse(() -> pure(2)).run();
+    Either<Throwable, Integer> result = parseInt("1").orElse(() -> pure(2)).safeRunSync();
 
     assertEquals(Either.right(1), result);
   }
 
   @Test
   public void orElseLeft() {
-    Either<Throwable, Integer> result = parseInt("kjsdfe").orElse(() -> pure(2)).run();
+    Either<Throwable, Integer> result = parseInt("kjsdfe").orElse(() -> pure(2)).safeRunSync();
 
     assertEquals(Either.right(2), result);
   }
@@ -114,7 +114,7 @@ public class EIOTest {
 
     EIO<Throwable, String> bracket = EIO.bracket(open(resultSet), getString("id"));
 
-    assertEquals(Either.right("value"), bracket.run());
+    assertEquals(Either.right("value"), bracket.safeRunSync());
     verify(resultSet).close();
   }
 

--- a/zio/src/test/java/com/github/tonivade/purefun/zio/UIOTest.java
+++ b/zio/src/test/java/com/github/tonivade/purefun/zio/UIOTest.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 
 import static com.github.tonivade.purefun.zio.UIO.from;
 import static com.github.tonivade.purefun.zio.UIO.pure;
+import static com.github.tonivade.purefun.zio.UIO.raiseError;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -85,14 +86,14 @@ public class UIOTest {
   }
 
   private UIO<ResultSet> open(ResultSet resultSet) {
-    return UIO.pure(resultSet);
+    return pure(resultSet);
   }
 
   private UIO<ResultSet> openError() {
-    return UIO.raiseError(new SQLException("error"));
+    return raiseError(new SQLException("error"));
   }
 
   private Function1<ResultSet, UIO<String>> getString(String column) {
-    return resultSet -> UIO.from(() -> resultSet.getString(column));
+    return resultSet -> from(() -> resultSet.getString(column));
   }
 }

--- a/zio/src/test/java/com/github/tonivade/purefun/zio/UIOTest.java
+++ b/zio/src/test/java/com/github/tonivade/purefun/zio/UIOTest.java
@@ -22,7 +22,7 @@ public class UIOTest {
 
   @Test
   public void mapRight() {
-    Integer result = parseInt("1").map(x -> x + 1).run();
+    Integer result = parseInt("1").map(x -> x + 1).unsafeRunSync();
 
     assertEquals(2, result);
   }
@@ -31,12 +31,12 @@ public class UIOTest {
   public void mapLeft() {
     UIO<Integer> result = parseInt("lskjdf").map(x -> x + 1);
 
-    assertThrows(NumberFormatException.class, result::run);
+    assertThrows(NumberFormatException.class, result::unsafeRunSync);
   }
 
   @Test
   public void flatMapRight() {
-    Integer result = parseInt("1").flatMap(x -> pure(x + 1)).run();
+    Integer result = parseInt("1").flatMap(x -> pure(x + 1)).unsafeRunSync();
 
     assertEquals(2, result);
   }
@@ -45,19 +45,19 @@ public class UIOTest {
   public void flatMapLeft() {
     UIO<Integer> result = parseInt("kjere").flatMap(x -> pure(x + 1));
 
-    assertThrows(NumberFormatException.class, result::run);
+    assertThrows(NumberFormatException.class, result::unsafeRunSync);
   }
 
   @Test
   public void redeemRight() {
-    Integer result = parseInt("1").recover(e -> -1).run();
+    Integer result = parseInt("1").recover(e -> -1).unsafeRunSync();
 
     assertEquals(1, result);
   }
 
   @Test
   public void redeemLeft() {
-    Integer result = parseInt("kjsdfdf").recover(e -> -1).run();
+    Integer result = parseInt("kjsdfdf").recover(e -> -1).unsafeRunSync();
 
     assertEquals(-1, result);
   }
@@ -69,7 +69,7 @@ public class UIOTest {
 
     UIO<String> bracket = UIO.bracket(open(resultSet), getString("id"));
 
-    assertEquals("value", bracket.run());
+    assertEquals("value", bracket.unsafeRunSync());
     verify(resultSet).close();
   }
 
@@ -77,7 +77,7 @@ public class UIOTest {
   public void bracketError() {
     UIO<String> bracket = UIO.bracket(openError(), getString("id"));
 
-    assertThrows(SQLException.class, bracket::run);
+    assertThrows(SQLException.class, bracket::unsafeRunSync);
   }
 
   private UIO<Integer> parseInt(String string) {

--- a/zio/src/test/java/com/github/tonivade/purefun/zio/UIOTest.java
+++ b/zio/src/test/java/com/github/tonivade/purefun/zio/UIOTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018-2019, Antonio Gabriel Muñoz Conejo <antoniogmc at gmail dot com>
+ * Distributed under the terms of the MIT License
+ */
+package com.github.tonivade.purefun.zio;
+
+import org.junit.jupiter.api.Test;
+
+import static com.github.tonivade.purefun.zio.UIO.from;
+import static com.github.tonivade.purefun.zio.UIO.pure;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UIOTest {
+
+  @Test
+  public void mapRight() {
+    Integer result = parseInt("1").map(x -> x + 1).run();
+
+    assertEquals(2, result);
+  }
+
+  @Test
+  public void mapLeft() {
+    UIO<Integer> result = parseInt("lskjdf").map(x -> x + 1);
+
+    assertThrows(NumberFormatException.class, result::run);
+  }
+
+  @Test
+  public void flatMapRight() {
+    Integer result = parseInt("1").flatMap(x -> pure(x + 1)).run();
+
+    assertEquals(2, result);
+  }
+
+  @Test
+  public void flatMapLeft() {
+    UIO<Integer> result = parseInt("kjere").flatMap(x -> pure(x + 1));
+
+    assertThrows(NumberFormatException.class, result::run);
+  }
+
+  private UIO<Integer> parseInt(String string) {
+    return from(() -> Integer.parseInt(string));
+  }
+}


### PR DESCRIPTION
So,

EIO<E, A> = ZIO<Nothing, E, A>
UIO<A> = EIO<Nothing, A> = ZIO<Nothing, Nothing, A>

But in Java there are no type aliases, so the only way is to reimplement with wrappers